### PR TITLE
Remove hyphen in composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "nickcheek/usps-lookup",
+    "name": "nickcheek/uspslookup",
     "type": "library",
     "description": "Php Wrapper for USPS API",
     "keywords": [


### PR DESCRIPTION
This was causing a problem with Mozart which was expecting the package name and directory name to match (which seems to be the convention).